### PR TITLE
Verify the TLS cert when making POST request

### DIFF
--- a/custom_components/stalbansrubbishcollections/client.py
+++ b/custom_components/stalbansrubbishcollections/client.py
@@ -60,7 +60,7 @@ class StAlbansRubbishCollectionsClient:
         return collection_data
     
     def _sync_request(self):
-        return requests.post(ENDPOINT_URI, headers=self.headers, json=self.data, verify=False)
+        return requests.post(ENDPOINT_URI, headers=self.headers, json=self.data)
 
     async def async_get_data(self):
         """Data refresh request from the coordinator"""


### PR DESCRIPTION
In 3932b05 the verify=False flag was added to the requests.post() call to stop it verifying the TLS cert. However, this causes an InsecureRequestWarning error in the home assistant log.

Removing this flag seems to work okay, at least with Python 3.13.3, and it's bad practice not to verify TLS certs when making HTTP requests, so remove the flag.